### PR TITLE
Use tarball instead of git repo to download the package

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = ros-melodic-costmap-converter
 	pkgdesc = ROS : converts costmaps
 	pkgver = 0.0.12
-	pkgrel = 1
+	pkgrel = 2
 	arch = any
 	license = BSD
 	makedepends = cmake
@@ -20,9 +20,8 @@ pkgbase = ros-melodic-costmap-converter
 	depends = ros-melodic-roscpp
 	depends = ros-melodic-std-msgs
 	depends = python-rospkg
-	options = !makeflags
-	source = ros-melodic-costmap-converter::git+https://github.com/rst-tu-dortmund/costmap_converter.git#tag=
-	sha256sums = SKIP
+	source = ros-melodic-costmap-converter-0.0.12.tar.gz::https://github.com/rst-tu-dortmund/costmap_converter/archive/0.0.12.tar.gz
+	sha256sums = 6b799f36c78c096e5bf0535c76ded14743b4b31da3a54603a183d73d09f054f3
 
 pkgname = ros-melodic-costmap-converter
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -6,7 +6,7 @@ pkgname='ros-melodic-costmap-converter'
 pkgver='0.0.12'
 _pkgver_patch=0
 arch=('any')
-pkgrel=1
+pkgrel=2
 license=('BSD')
 
 ros_makedepends=(ros-melodic-catkin)
@@ -26,12 +26,9 @@ ros-melodic-std-msgs)
 depends=(${ros_depends[@]}
   python-rospkg)
 
-# Git version (e.g. for debugging)
-_dir=${pkgname}
-_tag=${pkgver}
-source=("${_dir}"::"git+https://github.com/rst-tu-dortmund/costmap_converter.git#tag=${__tag}")
-sha256sums=('SKIP')
-options=('!makeflags')  
+_dir="costmap_converter-${pkgver}/"
+source=("${pkgname}-${pkgver}.tar.gz"::"https://github.com/rst-tu-dortmund/costmap_converter/archive/${pkgver}.tar.gz")
+sha256sums=('6b799f36c78c096e5bf0535c76ded14743b4b31da3a54603a183d73d09f054f3')
 
 build() {
   # Use ROS environment variables
@@ -46,7 +43,7 @@ build() {
   /usr/share/ros-build-tools/fix-python-scripts.sh -v 3 ${srcdir}/${_dir}
 
   # Build project
-  cmake ${srcdir}/${pkgname} \
+  cmake ${srcdir}/${_dir} \
         -DCMAKE_BUILD_TYPE=Release \
         -DCATKIN_BUILD_BINARY_PACKAGE=ON \
         -DCMAKE_INSTALL_PREFIX=/opt/ros/melodic \


### PR DESCRIPTION
Otherwise we would have to add git to the makedepends. However, I think
that downloading the tarball so we can actually check the checksum seems
like a good idea.